### PR TITLE
Updated FeedOvr and FeedCommanded per mtconnect/adapter/fanuc repo

### DIFF
--- a/Configurator/device.xml
+++ b/Configurator/device.xml
@@ -83,8 +83,8 @@
             <DataItem category="EVENT" id="[dev_id]_partcount_01" name="part_count" type="PART_COUNT"/>
             <DataItem category="SAMPLE" id="[dev_id]_pathposition_01" name="path_position" nativeUnits="MILLIMETER_3D" subType="ACTUAL" type="PATH_POSITION" units="MILLIMETER_3D"/>
             <DataItem category="SAMPLE" id="[dev_id]_pathfeedrate_01" name="path_feedrate" nativeUnits="MILLIMETER/SECOND" type="PATH_FEEDRATE" subType="ACTUAL" units="MILLIMETER/SECOND"/>
-            <DataItem category="SAMPLE" id="[dev_id]_feedcommanded_01" name="feed_commanded" nativeUnits="MILLIMETER/SECOND" type="PATH_FEEDRATE" subType="COMMANDED" units="MILLIMETER/SECOND"/>
-            <DataItem category="SAMPLE" id="[dev_id]_feedovr_01" name="feed_ovr" nativeUnits="PERCENT" subType="OVERRIDE" type="PATH_FEEDRATE" units="PERCENT"/>
+            <DataItem category="SAMPLE" id="[dev_id]_feedcommanded_01" name="f_command" nativeUnits="MILLIMETER/SECOND" type="PATH_FEEDRATE" subType="COMMANDED" units="MILLIMETER/SECOND"/>
+            <DataItem category="SAMPLE" id="[dev_id]_feedovr_01" name="Fovr" nativeUnits="PERCENT" subType="OVERRIDE" type="PATH_FEEDRATE" units="PERCENT"/>
           </DataItems>
         </Path>
       </Components>


### PR DESCRIPTION
Corrected the device.xml for Feed Override and Feed Commanded per the mtconnect/adapter/fanuc repo.

https://github.com/mtconnect/adapter/blob/master/fanuc/fanuc.xml#L90 